### PR TITLE
Fix sql structure for nb_views

### DIFF
--- a/struct_nb_view.sql
+++ b/struct_nb_view.sql
@@ -1,1 +1,1 @@
-ALTER TABLE article ADD nb_views INT;
+ALTER TABLE article ADD nb_views INT default 0;


### PR DESCRIPTION
Default was null, which affect Article object hydration because nb_views is intended to be an int.